### PR TITLE
Cancel ragdoll with isActionsLimited export

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -882,7 +882,10 @@ if Config.RagdollKeybind ~= '' then
             EmoteMenu.IsRagdoll = not EmoteMenu.IsRagdoll
             while EmoteMenu.IsRagdoll do
                 Wait(0)
-                if EmoteMenu.isActionsLimited then return end
+                if EmoteMenu.isActionsLimited then
+                    EmoteMenu.IsRagdoll = false
+                    return
+                end
                 if IsPedOnFoot(cache.ped) then
                     SetPedToRagdoll(cache.ped, 1000, 1000, 0, 0, 0, 0)
                 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -882,6 +882,7 @@ if Config.RagdollKeybind ~= '' then
             EmoteMenu.IsRagdoll = not EmoteMenu.IsRagdoll
             while EmoteMenu.IsRagdoll do
                 Wait(0)
+                if EmoteMenu.isActionsLimited then return end
                 if IsPedOnFoot(cache.ped) then
                     SetPedToRagdoll(cache.ped, 1000, 1000, 0, 0, 0, 0)
                 end


### PR DESCRIPTION
Currently the export will stop players from starting ragdoll but does nothing if the player is already toggled to ragdoll. Alternatively this could be its own export but I cannot think of any cases where this might be an issue.