### PR TITLE
Fix(props): Fix props being stuck when spamming prop emotes

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -138,9 +138,13 @@ lib.callback.register('scully_emotemenu:spawnProps', function(source, props)
         end, ('Failed to spawn prop %s'):format(prop.hash), 2000)
 
         if entityExsist then
-            local netObject = NetworkGetNetworkIdFromEntity(object)
+            if playerProps[source] then
+                deleteProps(src, props)
+            else
+                playerProps[source] = {}
+            end
 
-            if not playerProps[source] then playerProps[source] = {} end
+            local netObject = NetworkGetNetworkIdFromEntity(object)
 
             if prop.hasPTFX then Player(source).state:set('ptfxPropNet', netObject, true) end
 


### PR DESCRIPTION
Makes sure that if a player already has props spawned before trying to spawn new ones they get deleted.

Fixes https://github.com/Scullyy/scully_emotemenu/issues/35