### PR TITLE
Chore: Use lib.load for static data

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,20 +1,20 @@
 lib.locale()
 
 KVP = require 'client.modules.kvp'
-PedTypes = require 'client.data.ped_types'
+PedTypes = lib.load('client.data.ped_types')
 Utils = require 'shared.modules.utils'
-Config = require 'shared.data.config'
-Walks = require 'shared.data.walks'
-Scenarios = require 'shared.data.scenarios'
-Expressions = require 'shared.data.expressions'
+Config = lib.load('shared.data.config')
+Walks = lib.load('shared.data.walks')
+Scenarios = lib.load('shared.data.scenarios')
+Expressions = lib.load('shared.data.expressions')
 Emotes = {
-    require 'shared.data.emotes.general_emotes',
-    require 'shared.data.emotes.prop_emotes',
-    require 'shared.data.emotes.consumable_emotes',
-    require 'shared.data.emotes.dance_emotes',
-    require 'shared.data.emotes.synchronized_emotes',
-    require 'shared.data.emotes.synchronized_dance_emotes',
-    require 'shared.data.emotes.animal_emotes'
+    lib.load('shared.data.emotes.general_emotes'),
+    lib.load('shared.data.emotes.prop_emotes'),
+    lib.load('shared.data.emotes.consumable_emotes'),
+    lib.load('shared.data.emotes.dance_emotes'),
+    lib.load('shared.data.emotes.synchronized_emotes'),
+    lib.load('shared.data.emotes.synchronized_dance_emotes'),
+    lib.load('shared.data.emotes.animal_emotes')
 }
 
 EmoteBinds = KVP.getTable('keybinds')

--- a/shared/data/emotes/synchronized_dance_emotes.lua
+++ b/shared/data/emotes/synchronized_dance_emotes.lua
@@ -1,5 +1,5 @@
 local options = {}
-local emotes = require 'shared.data.emotes.dance_emotes'
+local emotes = lib.load('shared.data.emotes.dance_emotes')
 
 for i = 1, #emotes.options do
     local emote = emotes.options[i]


### PR DESCRIPTION
Since require also caches the data inside ox_lib for future reference we cache our "shared data" twice one instance in scully_emotemenu and another instance in ox_lib making memory usage higher.

An easy fix is to use lib.load which does the same as require but does not cache it for future use.

Here's the docs aswell:
https://overextended.dev/ox_lib/Modules/Require/Shared#libload

I have tested multiple emotes to make sure everything works but I havent tried syncronized dances.