### PR TITLE
Update handsup.lua

### DIFF
--- a/client/modules/handsup.lua
+++ b/client/modules/handsup.lua
@@ -1,58 +1,88 @@
+local DisableControlAction = DisableControlAction
+local IsPedSwimming = IsPedSwimming
+local DisablePlayerFiring = DisablePlayerFiring
+local IsPedRagdoll = IsPedRagdoll
+local TaskPlayAnim = TaskPlayAnim
+local StopAnimTask = StopAnimTask
+local RemoveAnimDict = RemoveAnimDict
+local SetPedToRagdoll = SetPedToRagdoll
+local IsEntityPlayingAnim = IsEntityPlayingAnim
+local GetEntityModel = GetEntityModel
+local IsThisModelACar = IsThisModelACar
+local GetVehiclePedIsEntering = GetVehiclePedIsEntering
+
+local function playHandsUpAnim(ped, dict, anim)
+    lib.requestAnimDict(dict)
+    TaskPlayAnim(ped, dict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
+end
+
+local function stopHandsUpAnim(ped, dict, anim)
+    StopAnimTask(ped, dict, anim, 8.0)
+    RemoveAnimDict(dict)
+end
+
 lib.addKeybind({
     name = 'handsupKey',
     description = locale('hands_up'),
     defaultKey = Config.handsUpKey,
-    onPressed = function()
-        if Config.handsUpIsToggle and PlayerState.handsup then PlayerState.handsup = false return end
-        if PlayerState.isLimited then return end
-        if GetVehiclePedIsEntering(cache.ped) ~= 0 then return end
 
-        local onBike = false
+    onPressed = function(self)
+        local ped = cache.ped
+        local vehicle = cache.vehicle
 
-        if cache.vehicle then
-            local model = GetEntityModel(cache.vehicle)
-
-            onBike = IsThisModelABike(model)
+        if Config.handsUpIsToggle and PlayerState.handsup then
+            PlayerState.handsup = false
+            return
         end
 
-        lib.requestAnimDict('random@mugging3')
-        TaskPlayAnim(cache.ped, 'random@mugging3', 'handsup_standing_base', 8.0, 8.0, -1, 50, 0, false, onBike and 4127 or false, false)
+        if PlayerState.isLimited then return end
+        if GetVehiclePedIsEntering(ped) ~= 0 then return end
+        if vehicle and not IsThisModelACar(GetEntityModel(vehicle)) then return end
 
+        self.dict = vehicle and "missheist_agency2ahands_up" or "random@mugging3"
+        self.anim = vehicle and "handsup_anxious" or "handsup_standing_base"
+
+        playHandsUpAnim(ped, self.dict, self.anim)
         PlayerState.handsup = true
 
         local needsReset = false
+
         CreateThread(function()
             while PlayerState.handsup do
                 Wait(0)
 
-                if cache.vehicle then
-                    DisableControlAction(0, 59, true)
-                end
-
                 DisableControlAction(0, 25, true)
                 DisablePlayerFiring(cache.playerId, true)
 
-                if IsPedRagdoll(cache.ped) then needsReset = true end
+                if vehicle then
+                    DisableControlAction(0, 59, true)
+                end
 
-                if (Config.handsUpIsToggle and not IsEntityPlayingAnim(cache.ped, 'random@mugging3', 'handsup_standing_base', 3)) or (needsReset and not IsPedRagdoll(cache.ped)) then
-                    TaskPlayAnim(cache.ped, 'random@mugging3', 'handsup_standing_base', 8.0, 8.0, -1, 50, 0, false, onBike and 4127 or false, false)
+                if IsPedSwimming(ped) and not IsPedRagdoll(ped) then
+                    SetPedToRagdoll(ped, 1000, 1000, 0, false, false, false)
+                end
+
+                if IsPedRagdoll(ped) then
+                    needsReset = true
+                elseif needsReset then
+                    playHandsUpAnim(ped, self.dict, self.anim)
                     needsReset = false
+                elseif Config.handsUpIsToggle
+                    and not IsEntityPlayingAnim(ped, self.dict, self.anim, 3) then
+                    playHandsUpAnim(ped, self.dict, self.anim)
                 end
             end
 
             if Config.handsUpIsToggle then
-                StopAnimTask(cache.ped, 'random@mugging3', 'handsup_standing_base', 8.0)
-                RemoveAnimDict('random@mugging3')
+                stopHandsUpAnim(ped, self.dict, self.anim)
             end
         end)
     end,
-    onReleased = not Config.handsUpIsToggle and function()
-        if PlayerState.isLimited then return end
-        if not PlayerState.handsup then return end
 
-        StopAnimTask(cache.ped, 'random@mugging3', 'handsup_standing_base', 8.0)
-        RemoveAnimDict('random@mugging3')
+    onReleased = not Config.handsUpIsToggle and function(self)
+        if PlayerState.isLimited or not PlayerState.handsup then return end
 
+        stopHandsUpAnim(cache.ped, self.dict, self.anim)
         PlayerState.handsup = false
     end
 })

--- a/client/modules/handsup.lua
+++ b/client/modules/handsup.lua
@@ -51,6 +51,8 @@ lib.addKeybind({
             while PlayerState.handsup do
                 Wait(0)
 
+                local currentPed = cache.ped
+
                 DisableControlAction(0, 25, true)
                 DisablePlayerFiring(cache.playerId, true)
 
@@ -58,23 +60,23 @@ lib.addKeybind({
                     DisableControlAction(0, 59, true)
                 end
 
-                if IsPedSwimming(ped) and not IsPedRagdoll(ped) then
-                    SetPedToRagdoll(ped, 1000, 1000, 0, false, false, false)
+                if IsPedSwimming(currentPed) and not IsPedRagdoll(currentPed) then
+                    SetPedToRagdoll(currentPed, 1000, 1000, 0, false, false, false)
                 end
 
-                if IsPedRagdoll(ped) then
+                if IsPedRagdoll(currentPed) then
                     needsReset = true
                 elseif needsReset then
-                    playHandsUpAnim(ped, self.dict, self.anim)
+                    playHandsUpAnim(currentPed, self.dict, self.anim)
                     needsReset = false
                 elseif Config.handsUpIsToggle
-                    and not IsEntityPlayingAnim(ped, self.dict, self.anim, 3) then
-                    playHandsUpAnim(ped, self.dict, self.anim)
+                    and not IsEntityPlayingAnim(currentPed, self.dict, self.anim, 3) then
+                    playHandsUpAnim(currentPed, self.dict, self.anim)
                 end
             end
 
             if Config.handsUpIsToggle then
-                stopHandsUpAnim(ped, self.dict, self.anim)
+                stopHandsUpAnim(currentPed, self.dict, self.anim)
             end
         end)
     end,


### PR DESCRIPTION
This commit refactored a bit of the old code, cached global fns, and introduced new animation when player is in vehicle (so hands are not clipping through models). Disables hands up in all vehicles that are not car (from my testing, did not manage to make any hands up animation work, hands are always forced on handles, even in helis / planes)