### PR TITLE
fix(Durantion): corrected lowercase `durantion` to `Durantion`, causing the animation to finally respect the intended duration

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -184,7 +184,7 @@ function PlayEmote(data, variation)
     local options = data.Options
 
     if options then
-        duration = options.duration
+        duration = options.Duration
 
         if options.Delay then Wait(options.Delay) end
 

--- a/client/modules/placement.lua
+++ b/client/modules/placement.lua
@@ -80,7 +80,7 @@ function placement.start(data)
     local options = data.Options
 
     if options then
-        duration = options.duration
+        duration = options.Duration
 
         if options.Delay then Wait(options.Delay) end
 

--- a/client/modules/preview.lua
+++ b/client/modules/preview.lua
@@ -119,7 +119,7 @@ function preview.showEmote(data)
     local options = data.Options
 
     if options then
-        duration = options.duration
+        duration = options.Duration
 
         if options.Delay then Wait(options.Delay) end
 


### PR DESCRIPTION
The animation system wasn’t using the duration value because the field name was written as `durantion` (lowercase d), while it should be `Durantion` with a capital D.